### PR TITLE
refactor: remove non-minimal varint handling

### DIFF
--- a/bitcoin-wasm/src/prelude.rs
+++ b/bitcoin-wasm/src/prelude.rs
@@ -156,19 +156,9 @@ macro_rules! impl_prefix_vec_access {
                 $class($module::$class::null())
             }
 
-            pub fn new_non_minimal(prefix_bytes: u8) -> Result<(), JsValue> {
-                $class::new().set_prefix_len(prefix_bytes)
-            }
-
             #[wasm_bindgen(method, getter)]
             pub fn length(&self) -> usize {
                 self.0.len()
-            }
-
-            pub fn set_prefix_len(&mut self, prefix_len: u8) -> Result<(), JsValue> {
-                self.0.set_prefix_len(prefix_len)
-                    .map_err(WasmError::from)
-                    .map_err(JsValue::from)
             }
 
             #[wasm_bindgen(method, getter)]

--- a/bitcoin/src/types/script.rs
+++ b/bitcoin/src/types/script.rs
@@ -24,7 +24,6 @@
 use std::ops::{Index, IndexMut};
 
 use riemann_core::{
-    ser::{SerResult},
     types::{
         tx::{RecipientIdentifier},
         primitives::{ConcretePrefixVec, PrefixVec},
@@ -59,12 +58,8 @@ macro_rules! wrap_script_type {
                 Self(Default::default())
             }
 
-            fn set_items(&mut self, v: Vec<Self::Item>) -> SerResult<()> {
+            fn set_items(&mut self, v: Vec<Self::Item>) {
                 self.0.set_items(v)
-            }
-
-            fn set_prefix_len(&mut self, prefix_len: u8) -> SerResult<()> {
-                self.0.set_prefix_len(prefix_len)
             }
 
             fn push(&mut self, i: Self::Item) {
@@ -261,26 +256,21 @@ mod test{
     #[test]
     fn it_serializes_and_derializes_scripts() {
         let cases = [
-        (
-            Script::new(hex::decode("0014758ce550380d964051086798d6546bebdca27a73".to_owned()).unwrap()),
-            "160014758ce550380d964051086798d6546bebdca27a73",
-            22
-        ),
-        (
-            Script::new(vec![]),
-            "00",
-            0
-        ),
-        (
-            Script::null(),
-            "00",
-            0
-        ),
-        (
-            Script::new_non_minimal(vec![], 9).unwrap(),
-            "ff0000000000000000",
-            0
-        ),
+            (
+                Script::new(hex::decode("0014758ce550380d964051086798d6546bebdca27a73".to_owned()).unwrap()),
+                "160014758ce550380d964051086798d6546bebdca27a73",
+                22
+            ),
+            (
+                Script::new(vec![]),
+                "00",
+                0
+            ),
+            (
+                Script::null(),
+                "00",
+                0
+            ),
         ];
         for case in cases.iter() {
             let prevout_script = Script::deserialize_hex(case.1.to_owned()).unwrap();

--- a/bitcoin/src/types/txin.rs
+++ b/bitcoin/src/types/txin.rs
@@ -234,18 +234,6 @@ mod test {
                 format!("{}{}{}", NULL_OUTPOINT, "00", "cdab3412")
             ),
             (
-                BitcoinTxIn{
-                    outpoint: Outpoint::null(),
-                    script_sig: ScriptSig::new_non_minimal(
-                        vec![0x00, 0x14, 0x11, 0x00, 0x33, 0x00, 0x55, 0x00, 0x77, 0x00, 0x99, 0x00, 0xbb, 0x00, 0xdd, 0x00, 0xff, 0x11, 0x00, 0x33, 0x00, 0x55],
-                        3
-                    ).unwrap(),
-                    sequence: 0x1234abcd
-
-                },
-                format!("{}{}{}", NULL_OUTPOINT, "fd1600001411003300550077009900bb00dd00ff1100330055", "cdab3412")
-            ),
-            (
                 BitcoinTxIn::new(
                     Outpoint::null(),
                     vec![],

--- a/core/src/ser.rs
+++ b/core/src/ser.rs
@@ -14,6 +14,10 @@ pub enum SerError{
     #[error("Bad VarInt length. Must be 1,3,5, or 9. Got {:?}.", .0)]
     BadVarIntLen(u8),
 
+    /// VarInts must be minimal.
+    #[error("Attempted to deserialize non-minmal VarInt. Someone is doing something fishy.")]
+    NonMinimalVarInt,
+
     /// IOError bubbled up from a `Write` passed to a `Ser::serialize` implementation.
     #[error("Serialization error")]
     IOError(#[from] IOError),

--- a/core/src/ser.rs
+++ b/core/src/ser.rs
@@ -14,17 +14,6 @@ pub enum SerError{
     #[error("Bad VarInt length. Must be 1,3,5, or 9. Got {:?}.", .0)]
     BadVarIntLen(u8),
 
-    /// Tried to add more inputs to a prefix vector, but the var int serialized length couldn't
-    /// be incremented.
-    #[error("VarInt length too short. Got {:?}. Need at least {:?} bytes.", .got, .need)]
-    VarIntTooShort{
-        /// The current VarInt length for `push_item()` operations. The proposed new length
-        /// for `set_prefix_len()` operations.
-        got: u8,
-        /// The minimum necessary VarInt length
-        need: u8
-    },
-
     /// IOError bubbled up from a `Write` passed to a `Ser::serialize` implementation.
     #[error("Serialization error")]
     IOError(#[from] IOError),

--- a/core/src/types/primitives.rs
+++ b/core/src/types/primitives.rs
@@ -102,7 +102,7 @@ where
         reader.read_exact(&mut prefix)?;  // read at most one byte
         let prefix_len = prefix_len_from_first_byte(prefix[0]);
 
-        // Get the byte(s) representing the vector length, as parse as u64
+        // Get the byte(s) representing the vector length, and parse as u64
         let expected_vector_length = if prefix_len > 1 {
             let mut buf = [0u8; 8];
             let mut body = reader.take(prefix_len as u64 - 1); // minus 1 to account for prefix


### PR DESCRIPTION
- [X] remove non-minimal VarInt support in-memory
- [x] remove non-minimal VarInt support in serialization+deserialization