### PR TITLE
refactor: remove lifetime from non-generic bip32 keys

### DIFF
--- a/bip32/src/curve/mod.rs
+++ b/bip32/src/curve/mod.rs
@@ -32,7 +32,7 @@ mod test {
 
     #[test]
     fn it_serializes_and_deserializes_affines() {
-        let backend = Secp256k1::init();
+        let backend = Secp256k1::static_ref();
         let privkey = Privkey::from_privkey_array([2u8; 32]).unwrap();
         let pubkey = backend.derive_pubkey(&privkey);
 

--- a/bip32/src/curve/model.rs
+++ b/bip32/src/curve/model.rs
@@ -89,7 +89,7 @@ pub trait RecoverableSigSerialize: SigSerialize {
 }
 
 /// A minmial curve-math backend interface
-pub trait Secp256k1Backend<'a>: Clone + std::fmt::Debug + PartialEq {
+pub trait Secp256k1Backend: Clone + std::fmt::Debug + PartialEq {
     /// An associated error type that can be converted into the crate's error type
     type Error: std::error::Error + Into<Bip32Error>;
     /// The underlying context type (if any)

--- a/bip32/src/derived.rs
+++ b/bip32/src/derived.rs
@@ -13,28 +13,28 @@ use crate::{
 ///
 /// For interface documentation see the page for
 /// [GenericDerivedPrivkey](struct.GenericDerivedPrivkey.html).
-pub type DerivedPrivkey<'a> = GenericDerivedPrivkey<'a, crate::curve::Secp256k1<'a>>;
+pub type DerivedPrivkey = GenericDerivedPrivkey<'static, crate::curve::Secp256k1<'static>>;
 
 /// A GenericDerivedPubkey using the compiled-in default backend, coupled with its (purported)
 /// derivation path.
 ///
 /// For interface documentation see the page for
 /// [GenericDerivedPubkey](struct.GenericDerivedPubkey.html).
-pub type DerivedPubkey<'a> = GenericDerivedPubkey<'a, crate::curve::Secp256k1<'a>>;
+pub type DerivedPubkey = GenericDerivedPubkey<'static, crate::curve::Secp256k1<'static>>;
 
 /// A GenericDerivedXPriv using the compiled-in default backend, coupled with its (purported)
 /// derivation path.
 ///
 /// For interface documentation see the page for
 ///  [GenericDerivedXPriv](struct.GenericDerivedXPriv.html).
-pub type DerivedXPriv<'a> = GenericDerivedXPriv<'a, crate::curve::Secp256k1<'a>>;
+pub type DerivedXPriv = GenericDerivedXPriv<'static, crate::curve::Secp256k1<'static>>;
 
 /// A GenericDerivedXPub using the compiled-in default backend, coupled with its (purported)
 /// derivation path.
 ///
 /// For interface documentation see the page for
 ///  [GenericDerivedXPub](struct.GenericDerivedXPub.html).
-pub type DerivedXPub<'a> = GenericDerivedXPub<'a, crate::curve::Secp256k1<'a>>;
+pub type DerivedXPub = GenericDerivedXPub<'static, crate::curve::Secp256k1<'static>>;
 
 make_derived_key!(
     /// A `Privkey` coupled with its (purported) derivation path. Generally this struct
@@ -49,7 +49,7 @@ make_derived_key!(
 inherit_has_privkey!(GenericDerivedPrivkey.privkey);
 inherit_backend!(GenericDerivedPrivkey.privkey);
 
-impl<'a, T: Secp256k1Backend<'a>> SigningKey<'a, T> for GenericDerivedPrivkey<'a, T> {
+impl<'a, T: Secp256k1Backend> SigningKey<'a, T> for GenericDerivedPrivkey<'a, T> {
     type VerifyingKey = GenericDerivedPubkey<'a, T>;
 
     fn derive_verifying_key(&self) -> Result<Self::VerifyingKey, Bip32Error> {
@@ -73,7 +73,7 @@ make_derived_key!(
 inherit_has_pubkey!(GenericDerivedPubkey.pubkey);
 inherit_backend!(GenericDerivedPubkey.pubkey);
 
-impl<'a, T: Secp256k1Backend<'a>> VerifyingKey<'a, T> for GenericDerivedPubkey<'a, T> {
+impl<'a, T: Secp256k1Backend> VerifyingKey<'a, T> for GenericDerivedPubkey<'a, T> {
     type SigningKey = GenericDerivedPrivkey<'a, T>;
 }
 
@@ -91,7 +91,7 @@ inherit_has_privkey!(GenericDerivedXPriv.xpriv);
 inherit_backend!(GenericDerivedXPriv.xpriv);
 inherit_has_xkeyinfo!(GenericDerivedXPriv.xpriv);
 
-impl<'a, T: Secp256k1Backend<'a>> GenericDerivedXPriv<'a, T> {
+impl<'a, T: Secp256k1Backend> GenericDerivedXPriv<'a, T> {
     /// Instantiate a master node using a custom HMAC key.
     pub fn custom_master_node(
         hmac_key: &[u8],
@@ -146,7 +146,7 @@ impl<'a, T: Secp256k1Backend<'a>> GenericDerivedXPriv<'a, T> {
     }
 }
 
-impl<'a, T: Secp256k1Backend<'a>> SigningKey<'a, T> for GenericDerivedXPriv<'a, T> {
+impl<'a, T: Secp256k1Backend> SigningKey<'a, T> for GenericDerivedXPriv<'a, T> {
     /// The corresponding verifying key
     type VerifyingKey = GenericDerivedXPub<'a, T>;
 
@@ -156,7 +156,7 @@ impl<'a, T: Secp256k1Backend<'a>> SigningKey<'a, T> for GenericDerivedXPriv<'a, 
     }
 }
 
-impl<'a, T: Secp256k1Backend<'a>> DerivePrivateChild<'a, T> for GenericDerivedXPriv<'a, T> {
+impl<'a, T: Secp256k1Backend> DerivePrivateChild<'a, T> for GenericDerivedXPriv<'a, T> {
     fn derive_private_child(&self, index: u32) -> Result<Self, Bip32Error> {
         Ok(Self {
             xpriv: self.xpriv.derive_private_child(index)?,
@@ -179,7 +179,7 @@ inherit_has_pubkey!(GenericDerivedXPub.xpub);
 inherit_backend!(GenericDerivedXPub.xpub);
 inherit_has_xkeyinfo!(GenericDerivedXPub.xpub);
 
-impl<'a, T: Secp256k1Backend<'a>> GenericDerivedXPub<'a, T> {
+impl<'a, T: Secp256k1Backend> GenericDerivedXPub<'a, T> {
     /// Check if this XPriv is the private ancestor of some other derived key
     pub fn is_public_ancestor_of<D: DerivedKey + HasPubkey<'a, T>>(
         &self,
@@ -194,11 +194,11 @@ impl<'a, T: Secp256k1Backend<'a>> GenericDerivedXPub<'a, T> {
     }
 }
 
-impl<'a, T: Secp256k1Backend<'a>> VerifyingKey<'a, T> for GenericDerivedXPub<'a, T> {
+impl<'a, T: Secp256k1Backend> VerifyingKey<'a, T> for GenericDerivedXPub<'a, T> {
     type SigningKey = GenericDerivedXPriv<'a, T>;
 }
 
-impl<'a, T: Secp256k1Backend<'a>> DerivePublicChild<'a, T> for GenericDerivedXPub<'a, T> {
+impl<'a, T: Secp256k1Backend> DerivePublicChild<'a, T> for GenericDerivedXPub<'a, T> {
     fn derive_public_child(&self, index: u32) -> Result<Self, Bip32Error> {
         Ok(Self {
             xpub: self.xpub.derive_public_child(index)?,
@@ -224,7 +224,7 @@ mod test {
         pub path: &'a [u32],
     }
 
-    fn validate_descendant<'a>(d: &KeyDeriv, m: &DerivedXPriv<'a>) {
+    fn validate_descendant(d: &KeyDeriv, m: &DerivedXPriv) {
         let path: DerivationPath = d.path.into();
 
         let m_pub = m.derive_verifying_key().unwrap();
@@ -265,9 +265,9 @@ mod test {
     #[test]
     fn bip32_vector_1() {
         let seed: [u8; 16] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15];
-        let backend = Secp256k1::init();
+        let backend = Secp256k1::static_ref();
 
-        let xpriv = DerivedXPriv::root_from_seed(&seed, Some(Hint::Legacy), &backend).unwrap();
+        let xpriv = DerivedXPriv::root_from_seed(&seed, Some(Hint::Legacy), backend).unwrap();
 
         let descendants = [
             KeyDeriv {
@@ -295,9 +295,9 @@ mod test {
     #[test]
     fn bip32_vector_2() {
         let seed = hex::decode(&"fffcf9f6f3f0edeae7e4e1dedbd8d5d2cfccc9c6c3c0bdbab7b4b1aeaba8a5a29f9c999693908d8a8784817e7b7875726f6c696663605d5a5754514e4b484542").unwrap();
-        let backend = Secp256k1::init();
+        let backend = Secp256k1::static_ref();
 
-        let xpriv = DerivedXPriv::root_from_seed(&seed, Some(Hint::Legacy), &backend).unwrap();
+        let xpriv = DerivedXPriv::root_from_seed(&seed, Some(Hint::Legacy), backend).unwrap();
 
         let descendants = [
             KeyDeriv { path: &[0] },
@@ -329,9 +329,9 @@ mod test {
     #[test]
     fn bip32_vector_3() {
         let seed = hex::decode(&"4b381541583be4423346c643850da4b320e46a87ae3d2a4e6da11eba819cd4acba45d239319ac14f863b8d5ab5a0d0c64d2e8a1e7d1457df2e5a3c51c73235be").unwrap();
-        let backend = Secp256k1::init();
+        let backend = Secp256k1::static_ref();
 
-        let xpriv = DerivedXPriv::root_from_seed(&seed, Some(Hint::Legacy), &backend).unwrap();
+        let xpriv = DerivedXPriv::root_from_seed(&seed, Some(Hint::Legacy), backend).unwrap();
 
         let descendants = [KeyDeriv {
             path: &[0 + BIP32_HARDEN],
@@ -346,10 +346,10 @@ mod test {
     fn it_can_sign_and_verify() {
         let digest = [1u8; 32];
         let wrong_digest = [2u8; 32];
-        let backend = Secp256k1::init();
+        let backend = Secp256k1::static_ref();
 
         let xpriv_str = "xprv9s21ZrQH143K3QTDL4LXw2F7HEK3wJUD2nW2nRk4stbPy6cq3jPPqjiChkVvvNKmPGJxWUtg6LnF5kejMRNNU3TGtRBeJgk33yuGBxrMPHi".to_owned();
-        let xpriv = MainnetEncoder::xpriv_from_base58(&xpriv_str, Some(&backend)).unwrap();
+        let xpriv = MainnetEncoder::xpriv_from_base58(&xpriv_str, Some(backend)).unwrap();
         let fake_deriv = KeyDerivation {
             root: [0, 0, 0, 0].into(),
             path: (0..0).collect(),
@@ -358,8 +358,8 @@ mod test {
         let mut key = DerivedXPriv::new(xpriv, fake_deriv);
         let mut key_pub = DerivedXPub::from_signing_key(&key).unwrap();
         // These had to go somewhere. here is as good as any
-        key.set_backend(&backend);
-        key_pub.set_backend(&backend);
+        key.set_backend(backend);
+        key_pub.set_backend(backend);
 
         // sign_digest + verify_digest
         let sig = key.sign_digest(digest).unwrap();
@@ -442,12 +442,12 @@ mod test {
     fn it_can_descendant_sign_and_verify() {
         let digest = [1u8; 32];
         let wrong_digest = [2u8; 32];
-        let backend = Secp256k1::init();
+        let backend = Secp256k1::static_ref();
 
         let path = vec![0u32, 1, 2];
 
         let xpriv_str = "xprv9s21ZrQH143K3QTDL4LXw2F7HEK3wJUD2nW2nRk4stbPy6cq3jPPqjiChkVvvNKmPGJxWUtg6LnF5kejMRNNU3TGtRBeJgk33yuGBxrMPHi".to_owned();
-        let xpriv = MainnetEncoder::xpriv_from_base58(&xpriv_str, Some(&backend)).unwrap();
+        let xpriv = MainnetEncoder::xpriv_from_base58(&xpriv_str, Some(backend)).unwrap();
         let fake_deriv = KeyDerivation {
             root: [0, 0, 0, 0].into(),
             path: (0..0).collect(),
@@ -457,8 +457,8 @@ mod test {
         let mut key_pub = DerivedXPub::from_signing_key(&key).unwrap();
         // These had to go somewhere. here is as good as any
         assert_eq!(key.derivation(), &fake_deriv);
-        key.set_backend(&backend);
-        key_pub.set_backend(&backend);
+        key.set_backend(backend);
+        key_pub.set_backend(backend);
 
         // sign_digest + verify_digest
         let sig = key.descendant_sign_digest(&path, digest).unwrap();
@@ -585,7 +585,7 @@ mod test {
 
     #[test]
     fn it_derives_verifying_keys() {
-        let backend = Secp256k1::init();
+        let backend = Secp256k1::static_ref();
         let fake_deriv = KeyDerivation {
             root: [0, 0, 0, 0].into(),
             path: (0..0).collect(),
@@ -595,7 +595,7 @@ mod test {
 
         let privkey = crate::keys::Privkey {
             key,
-            backend: Some(&backend),
+            backend: Some(backend),
         };
 
         let key = DerivedPrivkey::new(privkey, fake_deriv);
@@ -605,16 +605,16 @@ mod test {
 
     #[test]
     fn it_instantiates_derived_xprivs_from_seeds() {
-        let backend = Secp256k1::init();
-        GenericDerivedXPriv::root_from_seed(&[0u8; 32][..], None, &backend).unwrap();
+        let backend = Secp256k1::static_ref();
+        GenericDerivedXPriv::root_from_seed(&[0u8; 32][..], None, backend).unwrap();
 
-        let err_too_short = GenericDerivedXPriv::root_from_seed(&[0u8; 2][..], None, &backend);
+        let err_too_short = GenericDerivedXPriv::root_from_seed(&[0u8; 2][..], None, backend);
         match err_too_short {
             Err(Bip32Error::SeedTooShort) => {}
             _ => assert!(false, "expected err too short"),
         }
 
-        let err_too_short = GenericDerivedXPriv::root_from_seed(&[0u8; 2][..], None, &backend);
+        let err_too_short = GenericDerivedXPriv::root_from_seed(&[0u8; 2][..], None, backend);
         match err_too_short {
             Err(Bip32Error::SeedTooShort) => {}
             _ => assert!(false, "expected err too short"),
@@ -623,9 +623,9 @@ mod test {
 
     #[test]
     fn it_checks_ancestry() {
-        let backend = Secp256k1::init();
-        let m = GenericDerivedXPriv::root_from_seed(&[0u8; 32][..], None, &backend).unwrap();
-        let m2 = GenericDerivedXPriv::root_from_seed(&[1u8; 32][..], None, &backend).unwrap();
+        let backend = Secp256k1::static_ref();
+        let m = GenericDerivedXPriv::root_from_seed(&[0u8; 32][..], None, backend).unwrap();
+        let m2 = GenericDerivedXPriv::root_from_seed(&[1u8; 32][..], None, backend).unwrap();
         let m_pub = GenericDerivedXPub::from_signing_key(&m).unwrap();
         let cases = [
             (&m, &m_pub, true),

--- a/bip32/src/enc.rs
+++ b/bip32/src/enc.rs
@@ -391,7 +391,7 @@ params!(
 
 /// Parameterizable Bitcoin encoder
 #[derive(Debug, Clone)]
-pub struct BitcoinEncoder<P: NetworkParams>(PhantomData<P>);
+pub struct BitcoinEncoder<P: NetworkParams>(PhantomData<fn(P) -> P>);
 
 impl<P: NetworkParams> Encoder for BitcoinEncoder<P> {
     /// Serialize the xpub to `std::io::Write`

--- a/bip32/src/enc.rs
+++ b/bip32/src/enc.rs
@@ -77,7 +77,7 @@ pub trait Encoder {
     fn write_xpub<'a, W, T>(writer: &mut W, key: &GenericXPub<'a, T>) -> Result<usize, Bip32Error>
     where
         W: std::io::Write,
-        T: Secp256k1Backend<'a>;
+        T: Secp256k1Backend;
 
     /// Serialize the xpriv to `std::io::Write`
     fn write_xpriv<'a, W, T>(
@@ -86,7 +86,7 @@ pub trait Encoder {
     ) -> Result<usize, Bip32Error>
     where
         W: std::io::Write,
-        T: Secp256k1Backend<'a>;
+        T: Secp256k1Backend;
 
     #[doc(hidden)]
     fn read_depth<R>(reader: &mut R) -> Result<u8, Bip32Error>
@@ -136,7 +136,7 @@ pub trait Encoder {
     ) -> Result<GenericXPriv<'a, T>, Bip32Error>
     where
         R: std::io::Read,
-        T: Secp256k1Backend<'a>,
+        T: Secp256k1Backend,
     {
         let depth = Self::read_depth(reader)?;
         let parent = Self::read_parent(reader)?;
@@ -174,7 +174,7 @@ pub trait Encoder {
     ) -> Result<GenericXPriv<'a, T>, Bip32Error>
     where
         R: std::io::Read,
-        T: Secp256k1Backend<'a>,
+        T: Secp256k1Backend,
     {
         let mut buf = [0u8; 4];
         reader.read_exact(&mut buf)?;
@@ -207,7 +207,7 @@ pub trait Encoder {
     ) -> Result<GenericXPriv<'a, T>, Bip32Error>
     where
         R: std::io::Read,
-        T: Secp256k1Backend<'a>;
+        T: Secp256k1Backend;
 
     #[doc(hidden)]
     fn read_xpub_body<'a, R, T>(
@@ -217,7 +217,7 @@ pub trait Encoder {
     ) -> Result<GenericXPub<'a, T>, Bip32Error>
     where
         R: std::io::Read,
-        T: Secp256k1Backend<'a>,
+        T: Secp256k1Backend,
     {
         let depth = Self::read_depth(reader)?;
         let parent = Self::read_parent(reader)?;
@@ -249,7 +249,7 @@ pub trait Encoder {
     ) -> Result<GenericXPub<'a, T>, Bip32Error>
     where
         R: std::io::Read,
-        T: Secp256k1Backend<'a>,
+        T: Secp256k1Backend,
     {
         let mut buf = [0u8; 4];
         reader.read_exact(&mut buf)?;
@@ -282,12 +282,12 @@ pub trait Encoder {
     ) -> Result<GenericXPub<'a, T>, Bip32Error>
     where
         R: std::io::Read,
-        T: Secp256k1Backend<'a>;
+        T: Secp256k1Backend;
 
     /// Serialize an XPriv to base58
     fn xpriv_to_base58<'a, T>(k: &GenericXPriv<'a, T>) -> Result<String, Bip32Error>
     where
-        T: Secp256k1Backend<'a>,
+        T: Secp256k1Backend,
     {
         let mut v: Vec<u8> = vec![];
         Self::write_xpriv(&mut v, k)?;
@@ -297,7 +297,7 @@ pub trait Encoder {
     /// Serialize an XPub to base58
     fn xpub_to_base58<'a, T>(k: &GenericXPub<'a, T>) -> Result<String, Bip32Error>
     where
-        T: Secp256k1Backend<'a>,
+        T: Secp256k1Backend,
     {
         let mut v: Vec<u8> = vec![];
         Self::write_xpub(&mut v, k)?;
@@ -328,7 +328,7 @@ pub trait Encoder {
         backend: Option<&'a T>,
     ) -> Result<GenericXPriv<'a, T>, Bip32Error>
     where
-        T: Secp256k1Backend<'a>,
+        T: Secp256k1Backend,
     {
         let data = decode_b58_check(s)?;
         Self::read_xpriv(&mut &data[..], backend)
@@ -358,7 +358,7 @@ pub trait Encoder {
         backend: Option<&'a T>,
     ) -> Result<GenericXPub<'a, T>, Bip32Error>
     where
-        T: Secp256k1Backend<'a>,
+        T: Secp256k1Backend,
     {
         let data = decode_b58_check(s)?;
         Self::read_xpub(&mut &data[..], backend)
@@ -398,7 +398,7 @@ impl<P: NetworkParams> Encoder for BitcoinEncoder<P> {
     fn write_xpub<'a, W, T>(writer: &mut W, key: &GenericXPub<'a, T>) -> Result<usize, Bip32Error>
     where
         W: std::io::Write,
-        T: Secp256k1Backend<'a>,
+        T: Secp256k1Backend,
     {
         let version = match key.hint() {
             Hint::Legacy => P::PUB_VERSION,
@@ -415,7 +415,7 @@ impl<P: NetworkParams> Encoder for BitcoinEncoder<P> {
     fn write_xpriv<'a, W, T>(writer: &mut W, key: &GenericXPriv<'a, T>) -> Result<usize, Bip32Error>
     where
         W: std::io::Write,
-        T: Secp256k1Backend<'a>,
+        T: Secp256k1Backend,
     {
         let version = match key.hint() {
             Hint::Legacy => P::PRIV_VERSION,
@@ -435,7 +435,7 @@ impl<P: NetworkParams> Encoder for BitcoinEncoder<P> {
     ) -> Result<GenericXPriv<'a, T>, Bip32Error>
     where
         R: std::io::Read,
-        T: Secp256k1Backend<'a>,
+        T: Secp256k1Backend,
     {
         let mut buf = [0u8; 4];
         reader.read_exact(&mut buf)?;
@@ -460,7 +460,7 @@ impl<P: NetworkParams> Encoder for BitcoinEncoder<P> {
     ) -> Result<GenericXPub<'a, T>, Bip32Error>
     where
         R: std::io::Read,
-        T: Secp256k1Backend<'a>,
+        T: Secp256k1Backend,
     {
         let mut buf = [0u8; 4];
         reader.read_exact(&mut buf)?;

--- a/bip32/src/keys.rs
+++ b/bip32/src/keys.rs
@@ -9,31 +9,31 @@ use crate::{
 ///
 /// For interface documentation see the page for
 /// [GenericPrivkey](struct.GenericPrivkey.html).
-pub type Privkey<'a> = GenericPrivkey<'a, crate::Secp256k1<'a>>;
+pub type Privkey = GenericPrivkey<'static, crate::Secp256k1<'static>>;
 
 /// A Public Key using the crate's compiled-in backend.
 /// This defaults to libsecp for native, and parity's rust secp for wasm targets.
 ///
 /// For interface documentation see the page for
 /// [GenericPubkey](struct.GenericPubkey.html).
-pub type Pubkey<'a> = GenericPubkey<'a, crate::Secp256k1<'a>>;
+pub type Pubkey = GenericPubkey<'static, crate::Secp256k1<'static>>;
 
 /// A Private key with a reference to its associated backend
 #[derive(Copy, Clone, Debug, PartialEq)]
-pub struct GenericPrivkey<'a, T: Secp256k1Backend<'a>> {
+pub struct GenericPrivkey<'a, T: Secp256k1Backend> {
     /// The private key.
     pub key: T::Privkey,
     /// A reference to the backend. Many operations will return errors if this is None.
     pub backend: Option<&'a T>,
 }
 
-impl<'a, T: Secp256k1Backend<'a>> HasPrivkey<'a, T> for GenericPrivkey<'a, T> {
+impl<'a, T: Secp256k1Backend> HasPrivkey<'a, T> for GenericPrivkey<'a, T> {
     fn privkey(&self) -> &T::Privkey {
         &self.key
     }
 }
 
-impl<'a, T: Secp256k1Backend<'a>> HasBackend<'a, T> for GenericPrivkey<'a, T> {
+impl<'a, T: Secp256k1Backend> HasBackend<'a, T> for GenericPrivkey<'a, T> {
     fn set_backend(&mut self, backend: &'a T) {
         self.backend = Some(backend);
     }
@@ -43,7 +43,7 @@ impl<'a, T: Secp256k1Backend<'a>> HasBackend<'a, T> for GenericPrivkey<'a, T> {
     }
 }
 
-impl<'a, T: Secp256k1Backend<'a>> SigningKey<'a, T> for GenericPrivkey<'a, T> {
+impl<'a, T: Secp256k1Backend> SigningKey<'a, T> for GenericPrivkey<'a, T> {
     /// The corresponding verifying key
     type VerifyingKey = GenericPubkey<'a, T>;
 
@@ -58,14 +58,14 @@ impl<'a, T: Secp256k1Backend<'a>> SigningKey<'a, T> for GenericPrivkey<'a, T> {
 
 /// A Public key with a reference to its associated backend
 #[derive(Copy, Clone, Debug, PartialEq)]
-pub struct GenericPubkey<'a, T: Secp256k1Backend<'a>> {
+pub struct GenericPubkey<'a, T: Secp256k1Backend> {
     /// The public key.
     pub key: T::Pubkey,
     /// A reference to the backend. Many operations will return errors if this is None.
     pub backend: Option<&'a T>,
 }
 
-impl<'a, T: Secp256k1Backend<'a>> GenericPubkey<'a, T> {
+impl<'a, T: Secp256k1Backend> GenericPubkey<'a, T> {
     /// Recover a public key from a signed digest
     pub fn recover_from_signed_digest(
         backend: &'a T,
@@ -79,13 +79,13 @@ impl<'a, T: Secp256k1Backend<'a>> GenericPubkey<'a, T> {
     }
 }
 
-impl<'a, T: Secp256k1Backend<'a>> HasPubkey<'a, T> for GenericPubkey<'a, T> {
+impl<'a, T: Secp256k1Backend> HasPubkey<'a, T> for GenericPubkey<'a, T> {
     fn pubkey(&self) -> &T::Pubkey {
         &self.key
     }
 }
 
-impl<'a, T: Secp256k1Backend<'a>> HasBackend<'a, T> for GenericPubkey<'a, T> {
+impl<'a, T: Secp256k1Backend> HasBackend<'a, T> for GenericPubkey<'a, T> {
     fn set_backend(&mut self, backend: &'a T) {
         self.backend = Some(backend);
     }
@@ -95,6 +95,6 @@ impl<'a, T: Secp256k1Backend<'a>> HasBackend<'a, T> for GenericPubkey<'a, T> {
     }
 }
 
-impl<'a, T: Secp256k1Backend<'a>> VerifyingKey<'a, T> for GenericPubkey<'a, T> {
+impl<'a, T: Secp256k1Backend> VerifyingKey<'a, T> for GenericPubkey<'a, T> {
     type SigningKey = GenericPrivkey<'a, T>;
 }

--- a/bip32/src/lib.rs
+++ b/bip32/src/lib.rs
@@ -34,11 +34,11 @@
 //!
 //! // `init` sets up a new `lazy_static` backend. Successive calls will re-use that backend
 //! // without needing to re-initialize it.
-//! let backend = Secp256k1::init();
+//! let backend = Secp256k1::static_ref();
 //! let xpriv_str = "xprv9s21ZrQH143K3QTDL4LXw2F7HEK3wJUD2nW2nRk4stbPy6cq3jPPqjiChkVvvNKmPGJxWUtg6LnF5kejMRNNU3TGtRBeJgk33yuGBxrMPHi".to_owned();
 //!
 //! // Encoders are network specific due to the bip32 version byte spec
-//! let xpriv = MainnetEncoder::xpriv_from_base58(&xpriv_str, Some(&backend))?;
+//! let xpriv = MainnetEncoder::xpriv_from_base58(&xpriv_str, Some(backend))?;
 //!
 //! let child_xpriv = xpriv.derive_private_child(33)?;
 //! let sig = child_xpriv.sign_digest(digest)?;

--- a/bip32/src/model.rs
+++ b/bip32/src/model.rs
@@ -12,7 +12,7 @@ use crate::{
 };
 
 /// Any type that has access to a Secp256k1 backend.
-pub trait HasBackend<'a, T: Secp256k1Backend<'a>> {
+pub trait HasBackend<'a, T: Secp256k1Backend> {
     /// Set the backend. Useful if you have created a backend after making a key with a `None`
     /// backend.
     fn set_backend(&mut self, backend: &'a T);
@@ -22,7 +22,7 @@ pub trait HasBackend<'a, T: Secp256k1Backend<'a>> {
 }
 
 /// Any type that contains a private key.
-pub trait HasPrivkey<'a, T: Secp256k1Backend<'a>> {
+pub trait HasPrivkey<'a, T: Secp256k1Backend> {
     /// Return the associated private key
     fn privkey(&self) -> &T::Privkey;
 
@@ -33,7 +33,7 @@ pub trait HasPrivkey<'a, T: Secp256k1Backend<'a>> {
 }
 
 /// Any type that contains a public key
-pub trait HasPubkey<'a, T: Secp256k1Backend<'a>> {
+pub trait HasPubkey<'a, T: Secp256k1Backend> {
     /// Return the associated public key
     fn pubkey(&self) -> &T::Pubkey;
 
@@ -58,7 +58,7 @@ pub trait HasPubkey<'a, T: Secp256k1Backend<'a>> {
 /// Any type that has a private key and a backend may derive a public key.
 ///
 /// This is generically implemented for any type that implements `HasPrivkey` and `HasBackend`.
-pub trait CanDerivePubkey<'a, T: 'a + Secp256k1Backend<'a>>:
+pub trait CanDerivePubkey<'a, T: 'a + Secp256k1Backend>:
     HasPrivkey<'a, T> + HasBackend<'a, T>
 {
     /// Derive the public key. Note that this operation may fail if no backend is found. This
@@ -82,13 +82,13 @@ pub trait CanDerivePubkey<'a, T: 'a + Secp256k1Backend<'a>>:
 
 impl<'a, T, K> CanDerivePubkey<'a, T> for K
 where
-    T: 'a + Secp256k1Backend<'a>,
+    T: 'a + Secp256k1Backend,
     K: HasPrivkey<'a, T> + HasBackend<'a, T>,
 {
 }
 
 /// Any type that has a private key and a backend may derive a public key
-pub trait SigningKey<'a, T: 'a + Secp256k1Backend<'a>>:
+pub trait SigningKey<'a, T: 'a + Secp256k1Backend>:
     CanDerivePubkey<'a, T> + std::marker::Sized
 {
     /// The corresponding verifying key
@@ -138,7 +138,7 @@ pub trait SigningKey<'a, T: 'a + Secp256k1Backend<'a>>:
 }
 
 /// Any type that has a pubkey and a backend can verify signatures.
-pub trait VerifyingKey<'a, T: 'a + Secp256k1Backend<'a>>:
+pub trait VerifyingKey<'a, T: 'a + Secp256k1Backend>:
     HasPubkey<'a, T> + HasBackend<'a, T> + std::marker::Sized
 {
     /// The corresponding signing key type.
@@ -244,7 +244,7 @@ impl<T: HasXKeyInfo + std::marker::Sized + Clone> XKey for T {
 ///
 /// This is generically implemented for any type that implements `SigningKey` and
 /// `DerivePrivateChild`
-pub trait DerivePrivateChild<'a, T: Secp256k1Backend<'a>>: XKey + HasPrivkey<'a, T> {
+pub trait DerivePrivateChild<'a, T: Secp256k1Backend>: XKey + HasPrivkey<'a, T> {
     /// Derive a child privkey
     fn derive_private_child(&self, index: u32) -> Result<Self, Bip32Error>;
 
@@ -273,7 +273,7 @@ pub trait DerivePrivateChild<'a, T: Secp256k1Backend<'a>>: XKey + HasPrivkey<'a,
 ///
 /// This is generically implemented for any type that implements `VerifyingKey` and
 /// `DerivePublicChild`
-pub trait DerivePublicChild<'a, T: Secp256k1Backend<'a>>: XKey + HasPubkey<'a, T> {
+pub trait DerivePublicChild<'a, T: Secp256k1Backend>: XKey + HasPubkey<'a, T> {
     /// Derive a child pubkey
     fn derive_public_child(&self, index: u32) -> Result<Self, Bip32Error>;
 
@@ -305,7 +305,7 @@ pub trait DerivePublicChild<'a, T: Secp256k1Backend<'a>>: XKey + HasPubkey<'a, T
 /// Shortcuts for deriving and signing.
 ///
 /// This trait is implemented on all types that impl `DerivePublicChild` and `VerifyingKey`
-pub trait XSigning<'a, T: 'a + Secp256k1Backend<'a>>:
+pub trait XSigning<'a, T: 'a + Secp256k1Backend>:
     DerivePrivateChild<'a, T> + SigningKey<'a, T>
 {
     /// Derive a descendant, and have it sign a digest
@@ -389,7 +389,7 @@ pub trait XSigning<'a, T: 'a + Secp256k1Backend<'a>>:
 /// Shortcuts for deriving and signing.
 ///
 /// This trait is implemented on all types that impl `DerivePublicChild` and `VerifyingKey`
-pub trait XVerifying<'a, T: 'a + Secp256k1Backend<'a>>:
+pub trait XVerifying<'a, T: 'a + Secp256k1Backend>:
     DerivePublicChild<'a, T> + VerifyingKey<'a, T>
 {
     /// Verify a signature on a digest
@@ -481,14 +481,14 @@ pub trait XVerifying<'a, T: 'a + Secp256k1Backend<'a>>:
 
 impl<'a, T, K> XSigning<'a, T> for K
 where
-    T: 'a + Secp256k1Backend<'a>,
+    T: 'a + Secp256k1Backend,
     K: DerivePrivateChild<'a, T> + SigningKey<'a, T>,
 {
 }
 
 impl<'a, T, K> XVerifying<'a, T> for K
 where
-    T: 'a + Secp256k1Backend<'a>,
+    T: 'a + Secp256k1Backend,
     K: DerivePublicChild<'a, T> + VerifyingKey<'a, T>,
 {
 }

--- a/bip32/src/prelude.rs
+++ b/bip32/src/prelude.rs
@@ -27,7 +27,7 @@ macro_rules! params {
 
 macro_rules! inherit_backend {
     ($struct_name:ident.$attr:ident) => {
-        impl<'a, T: crate::curve::model::Secp256k1Backend<'a>> crate::model::HasBackend<'a, T>
+        impl<'a, T: crate::curve::model::Secp256k1Backend> crate::model::HasBackend<'a, T>
             for $struct_name<'a, T>
         {
             fn set_backend(&mut self, backend: &'a T) {
@@ -43,7 +43,7 @@ macro_rules! inherit_backend {
 
 macro_rules! inherit_has_privkey {
     ($struct_name:ident.$attr:ident) => {
-        impl<'a, T: crate::curve::model::Secp256k1Backend<'a>> crate::model::HasPrivkey<'a, T>
+        impl<'a, T: crate::curve::model::Secp256k1Backend> crate::model::HasPrivkey<'a, T>
             for $struct_name<'a, T>
         {
             fn privkey(&self) -> &T::Privkey {
@@ -55,7 +55,7 @@ macro_rules! inherit_has_privkey {
 
 macro_rules! inherit_has_pubkey {
     ($struct_name:ident.$attr:ident) => {
-        impl<'a, T: crate::curve::model::Secp256k1Backend<'a>> crate::model::HasPubkey<'a, T>
+        impl<'a, T: crate::curve::model::Secp256k1Backend> crate::model::HasPubkey<'a, T>
             for $struct_name<'a, T>
         {
             fn pubkey(&self) -> &T::Pubkey {
@@ -67,7 +67,7 @@ macro_rules! inherit_has_pubkey {
 
 macro_rules! inherit_has_xkeyinfo {
     ($struct_name:ident.$attr:ident) => {
-        impl<'a, T: crate::curve::model::Secp256k1Backend<'a>> crate::model::HasXKeyInfo
+        impl<'a, T: crate::curve::model::Secp256k1Backend> crate::model::HasXKeyInfo
             for $struct_name<'a, T>
         {
             fn xkey_info(&self) -> &crate::primitives::XKeyInfo {
@@ -84,14 +84,14 @@ macro_rules! make_derived_key {
     ) => {
         $(#[$outer])*
         #[derive(Clone, Debug, PartialEq)]
-        pub struct $struct_name<'a, T: Secp256k1Backend<'a>> {
+        pub struct $struct_name<'a, T: Secp256k1Backend> {
             /// The underlying key
             pub $attr: $underlying<'a, T>,
             /// Its derivation from some master key
             pub derivation: crate::path::KeyDerivation,
         }
 
-        impl<'a, T: Secp256k1Backend<'a>> crate::model::DerivedKey for $struct_name<'a, T> {
+        impl<'a, T: Secp256k1Backend> crate::model::DerivedKey for $struct_name<'a, T> {
             type Key = $underlying<'a, T>;
 
             fn new(k: Self::Key, derivation: KeyDerivation) -> Self {

--- a/bip32/src/xkeys.rs
+++ b/bip32/src/xkeys.rs
@@ -18,6 +18,31 @@ type HmacSha512 = Hmac<Sha512>;
 /// [GenericXPriv](struct.GenericXPriv.html).
 pub type XPriv = GenericXPriv<'static, crate::curve::Secp256k1<'static>>;
 
+impl XPriv {
+    /// Generate a customized master node using the static backend
+    pub fn master_node(
+        hmac_key: &[u8],
+        data: &[u8],
+        hint: Option<Hint>,
+    ) -> Result<XPriv, Bip32Error> {
+        Self::custom_master_node(hmac_key, data, hint, crate::curve::Secp256k1::static_ref())
+    }
+
+    /// Generate a master node from some seed data. Uses the BIP32-standard hmac key.
+    ///
+    ///
+    /// # Important:
+    ///
+    /// Use a seed of AT LEAST 128 bits.
+    pub fn root_from_seed(
+        data: &[u8],
+        hint: Option<Hint>
+    ) -> Result<XPriv, Bip32Error> {
+        Self::custom_root_from_seed(data, hint, crate::curve::Secp256k1::static_ref())
+    }
+}
+
+
 /// A BIP32 Extended pubkey using the library's compiled-in secp256k1 backend. This defaults to
 /// libsecp for native, and parity's rust secp for wasm targets
 ///
@@ -93,7 +118,7 @@ impl<'a, T: Secp256k1Backend> GenericXPriv<'a, T> {
     /// # Important:
     ///
     /// Use a seed of AT LEAST 128 bits.
-    pub fn root_from_seed(
+    pub fn custom_root_from_seed(
         data: &[u8],
         hint: Option<Hint>,
         backend: &'a T,
@@ -265,7 +290,7 @@ mod test {
         let seed: [u8; 16] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15];
         let backend = Secp256k1::static_ref();
 
-        let xpriv = XPriv::root_from_seed(&seed, Some(Hint::Legacy), &backend).unwrap();
+        let xpriv = XPriv::root_from_seed(&seed, Some(Hint::Legacy)).unwrap();
         let xpub = xpriv.to_xpub().unwrap();
 
         let expected_xpub = "xpub661MyMwAqRbcFtXgS5sYJABqqG9YLmC4Q1Rdap9gSE8NqtwybGhePY2gZ29ESFjqJoCu1Rupje8YtGqsefD265TMg7usUDFdp6W1EGMcet8";
@@ -324,7 +349,7 @@ mod test {
         let seed = hex::decode(&"fffcf9f6f3f0edeae7e4e1dedbd8d5d2cfccc9c6c3c0bdbab7b4b1aeaba8a5a29f9c999693908d8a8784817e7b7875726f6c696663605d5a5754514e4b484542").unwrap();
         let backend = Secp256k1::static_ref();
 
-        let xpriv = XPriv::root_from_seed(&seed, Some(Hint::Legacy), &backend).unwrap();
+        let xpriv = XPriv::root_from_seed(&seed, Some(Hint::Legacy)).unwrap();
         let xpub = xpriv.to_xpub().unwrap();
 
         let expected_xpub = "xpub661MyMwAqRbcFW31YEwpkMuc5THy2PSt5bDMsktWQcFF8syAmRUapSCGu8ED9W6oDMSgv6Zz8idoc4a6mr8BDzTJY47LJhkJ8UB7WEGuduB";
@@ -383,7 +408,7 @@ mod test {
         let seed = hex::decode(&"4b381541583be4423346c643850da4b320e46a87ae3d2a4e6da11eba819cd4acba45d239319ac14f863b8d5ab5a0d0c64d2e8a1e7d1457df2e5a3c51c73235be").unwrap();
         let backend = Secp256k1::static_ref();
 
-        let xpriv = XPriv::root_from_seed(&seed, Some(Hint::Legacy), &backend).unwrap();
+        let xpriv = XPriv::root_from_seed(&seed, Some(Hint::Legacy)).unwrap();
         let xpub = xpriv.to_xpub().unwrap();
 
         let expected_xpub = "xpub661MyMwAqRbcEZVB4dScxMAdx6d4nFc9nvyvH3v4gJL378CSRZiYmhRoP7mBy6gSPSCYk6SzXPTf3ND1cZAceL7SfJ1Z3GC8vBgp2epUt13";

--- a/bitcoin/src/builder.rs
+++ b/bitcoin/src/builder.rs
@@ -72,7 +72,7 @@ pub struct LegacyBuilder<T: AddressEncoder> {
     vin: Vec<BitcoinTxIn>,
     vout: Vec<TxOut>,
     locktime: u32,
-    encoder: PhantomData<T>,
+    encoder: PhantomData<fn(T) -> T>,
 }
 
 /// WitnessBuilder implements `TxBuilder` and `WitTxBuilder`. The only difference between

--- a/bitcoin/src/enc/encoder.rs
+++ b/bitcoin/src/enc/encoder.rs
@@ -57,7 +57,7 @@ pub trait BitcoinEncoderMarker:
 /// The standard encoder for Bitcoin networks. Parameterized by a `NetworkParams` type and an
 /// `rmn_bip32::Encoder`. It exposes
 #[derive(Debug, Clone, PartialEq)]
-pub struct BitcoinEncoder<P: NetworkParams>(PhantomData<P>);
+pub struct BitcoinEncoder<P: NetworkParams>(PhantomData<fn(P) -> P>);
 
 impl<P: NetworkParams> AddressEncoder for BitcoinEncoder<P> {
     type Address = Address;

--- a/bitcoin/src/nets.rs
+++ b/bitcoin/src/nets.rs
@@ -81,7 +81,7 @@ pub trait BitcoinNetwork: Network {
 /// A newtype for Bitcoin networks, parameterized by an encoder. We change the encoder to
 /// differentiate between main, test, and signet.
 #[derive(Debug)]
-pub struct Bitcoin<T: AddressEncoder>(PhantomData<T>);
+pub struct Bitcoin<T: AddressEncoder>(PhantomData<fn(T) -> T>);
 
 impl<T> Network for Bitcoin<T>
 where

--- a/bitcoin/src/types/script.rs
+++ b/bitcoin/src/types/script.rs
@@ -90,7 +90,7 @@ impl ScriptPubkey {
     /// Instantiate a standard p2pkh script pubkey from a pubkey.
     pub fn p2pkh<'a, T, B>(key: &T) -> Self
     where
-        B: rmn_bip32::curve::Secp256k1Backend<'a>,
+        B: rmn_bip32::curve::Secp256k1Backend,
         T: rmn_bip32::model::HasPubkey<'a, B>,
     {
         let mut v: Vec<u8> = vec![0x76, 0xa9, 0x14]; // DUP, HASH160, PUSH_20
@@ -102,7 +102,7 @@ impl ScriptPubkey {
     /// Instantiate a standard p2wpkh script pubkey from a pubkey.
     pub fn p2wpkh<'a, T, B>(key: &T) -> Self
     where
-        B: rmn_bip32::curve::Secp256k1Backend<'a>,
+        B: rmn_bip32::curve::Secp256k1Backend,
         T: rmn_bip32::model::HasPubkey<'a, B>,
     {
         let mut v: Vec<u8> = vec![0x00, 0x14]; // OP_0, PUSH_20

--- a/bitcoin/src/types/utxo.rs
+++ b/bitcoin/src/types/utxo.rs
@@ -8,9 +8,7 @@
 //!
 //! This functionality does NOT currently support nested witness-via-p2sh prevouts. If you' like
 //! to use those, you'll need a processing step in your tx signer.
-use crate::{
-    types::{BitcoinOutpoint, BitcoinTransaction, Script, ScriptPubkey, ScriptType, TxOut},
-};
+use crate::types::{BitcoinOutpoint, BitcoinTransaction, Script, ScriptPubkey, ScriptType, TxOut};
 use serde::{Deserialize, Serialize};
 
 /// This type specifies whether a script is known to be none, or whether it is unknown.
@@ -112,10 +110,10 @@ impl UTXO {
                         v.extend(&payload);
                         v.extend(&[0x88, 0xac]);
                         Some(v.into())
-                    },
-                    _ => None , // Should be unreachable
+                    }
+                    _ => None, // Should be unreachable
                 }
-            },
+            }
             SpendScript::Known(script) => Some(script.clone()),
             SpendScript::Missing => None,
         }

--- a/core/src/builder.rs
+++ b/core/src/builder.rs
@@ -29,9 +29,7 @@ pub trait TxBuilder: std::marker::Sized {
     fn from_tx(tx: Self::Transaction) -> Self;
 
     /// Instantiate a new builder from a `std::io::Read` that contains a serialized tx
-    fn read_from_tx<R>(
-        reader: &mut R,
-    ) -> Result<Self, <Self::Transaction as Transaction>::TxError>
+    fn read_from_tx<R>(reader: &mut R) -> Result<Self, <Self::Transaction as Transaction>::TxError>
     where
         R: Read,
     {
@@ -68,11 +66,7 @@ pub trait TxBuilder: std::marker::Sized {
     /// ## Note
     ///
     /// This may invalidate signatures made using ANYONECANPAY.
-    fn insert_input(
-        self,
-        index: usize,
-        input: <Self::Transaction as Transaction>::TxIn,
-    ) -> Self;
+    fn insert_input(self, index: usize, input: <Self::Transaction as Transaction>::TxIn) -> Self;
 
     /// Add a set of inputs to the transaction.
     fn extend_inputs<I>(self, inputs: I) -> Self
@@ -84,11 +78,8 @@ pub trait TxBuilder: std::marker::Sized {
     /// ## Note
     ///
     /// This may invalidate signatures made using SINGLE.
-    fn insert_output(
-        self,
-        index: usize,
-        output: <Self::Transaction as Transaction>::TxOut,
-    ) -> Self;
+    fn insert_output(self, index: usize, output: <Self::Transaction as Transaction>::TxOut)
+        -> Self;
 
     /// Add a set of outputs to the transaction.
     fn extend_outputs<I>(self, outputs: I) -> Self

--- a/core/src/hashes/mod.rs
+++ b/core/src/hashes/mod.rs
@@ -13,6 +13,6 @@ pub mod hash256;
 /// Tooling for blake2b256
 pub mod blake2b256;
 
+pub use blake2b256::*;
 pub use hash256::*;
 pub use marked::*;
-pub use blake2b256::*;

--- a/core/src/nets.rs
+++ b/core/src/nets.rs
@@ -70,9 +70,7 @@ pub trait Network {
     }
 
     /// Instantiate a builder from a hex-serialized transaction
-    fn builder_from_hex(
-        hex_tx: &str,
-    ) -> Result<Self::Builder, <Self::Tx as Transaction>::TxError> {
+    fn builder_from_hex(hex_tx: &str) -> Result<Self::Builder, <Self::Tx as Transaction>::TxError> {
         Self::Builder::from_hex_tx(hex_tx)
     }
 

--- a/ledger-btc/src/utils.rs
+++ b/ledger-btc/src/utils.rs
@@ -26,13 +26,13 @@ pub(crate) enum Commands {
     UNTRUSTED_HASH_TX_INPUT_FINALIZE_FULL = 0x4a,
 }
 
-pub(crate) struct InternalKeyInfo<'a> {
-    pub(crate) pubkey: Pubkey<'a>,
+pub(crate) struct InternalKeyInfo {
+    pub(crate) pubkey: Pubkey,
     pub(crate) path: DerivationPath,
     pub(crate) chain_code: ChainCode,
 }
 
-pub(crate) fn parse_pubkey_response<'a>(deriv: &DerivationPath, data: &[u8], backend: Option<&'a rmn_bip32::Secp256k1<'a>>) -> InternalKeyInfo<'a> {
+pub(crate) fn parse_pubkey_response(deriv: &DerivationPath, data: &[u8]) -> InternalKeyInfo {
     let mut chain_code = [0u8; 32];
     chain_code.copy_from_slice(&data[data.len() - 32..]);
 
@@ -41,7 +41,7 @@ pub(crate) fn parse_pubkey_response<'a>(deriv: &DerivationPath, data: &[u8], bac
     InternalKeyInfo {
         pubkey: rmn_bip32::keys::Pubkey {
             key: PointDeserialize::from_pubkey_array_uncompressed(pk).unwrap(),
-            backend,
+            backend: Some(rmn_bip32::Secp256k1::static_ref()),
         },
         path: deriv.clone(),
         chain_code: chain_code.into(),

--- a/psbt/src/input.rs
+++ b/psbt/src/input.rs
@@ -1,6 +1,5 @@
 use riemann_core::ser::{self, ByteFormat};
 use rmn_bip32::{
-    self as bip32,
     curve::{model::Secp256k1Backend, SigSerialize},
     derived::DerivedPubkey,
     model::HasPubkey,
@@ -197,17 +196,14 @@ impl PSBTInput {
     }
 
     /// Returns an iterator over Pubkey/Signature pairs
-    pub fn partial_sigs<'a>(
-        &self,
-        backend: Option<&'a bip32::Secp256k1<'a>>,
-    ) -> Vec<(rmn_bip32::Pubkey<'a>, rmn_bip32::Signature, Sighash)> {
+    pub fn partial_sigs<'a>(&self) -> Vec<(rmn_bip32::Pubkey, rmn_bip32::Signature, Sighash)> {
         self.raw_partial_sigs()
-            .filter_map(|(k, v)| schema::try_kv_pair_as_pubkey_and_sig(k, v, backend).ok())
+            .filter_map(|(k, v)| schema::try_kv_pair_as_pubkey_and_sig(k, v).ok())
             .collect::<Vec<_>>()
     }
 
     /// Inserts a signature into the map
-    pub fn insert_partial_sig<'a, T: Secp256k1Backend<'a>, K: HasPubkey<'a, T>>(
+    pub fn insert_partial_sig<'a, T: Secp256k1Backend, K: HasPubkey<'a, T>>(
         &mut self,
         pk: &K,
         sig: &T::Signature,
@@ -275,12 +271,9 @@ impl PSBTInput {
     }
 
     /// Returns a vec containing parsed public keys. Unparsable keys will be ignored
-    pub fn parsed_pubkey_derivations<'a>(
-        &self,
-        backend: Option<&'a bip32::Secp256k1<'a>>,
-    ) -> Vec<DerivedPubkey<'a>> {
+    pub fn parsed_pubkey_derivations<'a>(&self) -> Vec<DerivedPubkey> {
         self.pubkey_kv_pairs()
-            .map(|(k, v)| schema::try_kv_pair_as_derived_pubkey(k, v, backend))
+            .map(|(k, v)| schema::try_kv_pair_as_derived_pubkey(k, v))
             .filter_map(Result::ok)
             .collect()
     }

--- a/psbt/src/lib.rs
+++ b/psbt/src/lib.rs
@@ -112,8 +112,8 @@ pub struct PSBT<T: BitcoinEncoderMarker, E: Bip32Encoder> {
     /// Per-output attribute maps
     outputs: Vec<PSBTOutput>,
     /// Sppoooopppy
-    encoder: PhantomData<T>,
-    bip32_encoder: PhantomData<E>,
+    encoder: PhantomData<fn(T) -> T>,
+    bip32_encoder: PhantomData<fn(E) -> E>,
 }
 
 impl<T: BitcoinEncoderMarker, E: Bip32Encoder> serde::Serialize for PSBT<T, E> {

--- a/psbt/src/output.rs
+++ b/psbt/src/output.rs
@@ -1,6 +1,6 @@
 use std::collections::{btree_map, BTreeMap};
 
-use rmn_bip32::{self as bip32, derived::DerivedPubkey};
+use rmn_bip32::derived::DerivedPubkey;
 
 use rmn_btc::types::script::Script;
 
@@ -84,12 +84,9 @@ impl PSBTOutput {
     }
 
     /// Returns a vec containing parsed public keys. Unparsable keys will be ignored
-    pub fn parsed_pubkey_derivations<'a>(
-        &self,
-        backend: Option<&'a bip32::Secp256k1<'a>>,
-    ) -> Vec<DerivedPubkey<'a>> {
+    pub fn parsed_pubkey_derivations<'a>(&self) -> Vec<DerivedPubkey> {
         self.pubkey_kv_pairs()
-            .map(|(k, v)| schema::try_kv_pair_as_derived_pubkey(k, v, backend))
+            .map(|(k, v)| schema::try_kv_pair_as_derived_pubkey(k, v))
             .filter_map(Result::ok)
             .collect()
     }

--- a/psbt/src/roles/finalizer.rs
+++ b/psbt/src/roles/finalizer.rs
@@ -45,7 +45,7 @@ where
 
         // If any pubkeys match, build a witness and finalize
         if let Some((pubkey, partial_sig, sighash)) = input_map
-            .partial_sigs(None)
+            .partial_sigs()
             .iter()
             .find(|(pubkey, _, _)| pkh == pubkey.pubkey_hash160())
         {

--- a/psbt/src/roles/ledger_signer.rs
+++ b/psbt/src/roles/ledger_signer.rs
@@ -52,10 +52,10 @@ where
     type Error = LedgerSignerError;
 
     fn is_change(&self, pst: &PSBT<A, E>, idx: usize) -> bool {
-        let pubkeys = pst.outputs[idx].parsed_pubkey_derivations(None);
+        let pubkeys = pst.outputs[idx].parsed_pubkey_derivations();
         if pubkeys.len() == 1 {
             let key = &pubkeys[0];
-            let xpub_res = block_on(self.get_xpub(&key.derivation.path, None));
+            let xpub_res = block_on(self.get_xpub(&key.derivation.path));
             if let Ok(xpub) = xpub_res {
                 return xpub.xpub.pubkey == key.pubkey && xpub.derivation == key.derivation;
             }
@@ -76,9 +76,9 @@ where
             return Err(LedgerSignerError::UnsupportedNestedSegwit);
         }
 
-        let pubkeys = input_map.parsed_pubkey_derivations(None);
+        let pubkeys = input_map.parsed_pubkey_derivations();
         for key in pubkeys {
-            let xpub = block_on(self.get_xpub(&key.derivation.path, None))?;
+            let xpub = block_on(self.get_xpub(&key.derivation.path))?;
             if xpub.xpub.pubkey == key.pubkey && xpub.derivation == key.derivation {
                 return Ok(());
             }
@@ -107,7 +107,7 @@ where
         let sig_infos = block_on(self.get_tx_signatures(&tx.into_witness(), &signing_info))?;
 
         for sig_info in sig_infos.iter() {
-            let key = block_on(self.get_xpub(&sig_info.deriv.path, None))?;
+            let key = block_on(self.get_xpub(&sig_info.deriv.path))?;
             pst.inputs[sig_info.input_idx].insert_partial_sig(&key, &sig_info.sig);
         }
 
@@ -122,7 +122,7 @@ fn extract_signing_info(
 ) -> Result<Vec<SigningInfo>, PSBTError> {
     let prevout = input_map.as_utxo(&tx.inputs()[idx].outpoint)?;
     Ok(input_map
-        .parsed_pubkey_derivations(None)
+        .parsed_pubkey_derivations()
         .iter()
         .map(|key| SigningInfo {
             input_idx: idx,


### PR DESCRIPTION
- Adds a lazy_static backend to the default backend types
- removes `<'a>` lifetime and backend passing from bip32 keys in PSBT by forcing use of the static backend
  - this is technically a feature downgrade, but oh my god it simplifies the experience